### PR TITLE
Fix bpm calculation

### DIFF
--- a/frontend/composables/useLoadTrackOnDeck.ts
+++ b/frontend/composables/useLoadTrackOnDeck.ts
@@ -34,7 +34,8 @@ export async function useLoadTrackOnDeck(
     wavesurfer.setVolume(deck.volume);
     wavesurfer.zoom(deck.zoom);
     deck.isWaveformReady = true;
-    // deck.bpm = await analyze(wavesurfer.getDecodedData());
+    deck.bpm = await analyze(wavesurfer.getDecodedData());
+    console.log(deck.bpm);
   });
   wavesurfer.on("play", () => {
     deck.isPlaying = true;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "@heroicons/vue": "^2.0.17",
     "@material-tailwind/html": "^2.0.0",
     "flowbite": "^1.6.5",
-    "wavesurfer.js": "^7.1.5",
+    "wavesurfer.js": "^7.3.2",
     "web-audio-beat-detector": "^8.1.44"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,6 @@
     "@material-tailwind/html": "^2.0.0",
     "flowbite": "^1.6.5",
     "wavesurfer.js": "^7.3.2",
-    "web-audio-beat-detector": "^8.1.44"
+    "web-audio-beat-detector": "^8.1.53"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^7.3.2
     version: 7.3.2
   web-audio-beat-detector:
-    specifier: ^8.1.44
-    version: 8.1.44
+    specifier: ^8.1.53
+    version: 8.1.53
 
 devDependencies:
   '@nuxt/test-utils':
@@ -511,11 +511,11 @@ packages:
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.11)
     dev: true
 
-  /@babel/runtime@7.21.0:
-    resolution: {integrity: sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==}
+  /@babel/runtime@7.22.15:
+    resolution: {integrity: sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.11
+      regenerator-runtime: 0.14.0
     dev: false
 
   /@babel/standalone@7.21.4:
@@ -3072,12 +3072,12 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
-  /automation-events@5.0.3:
-    resolution: {integrity: sha512-ZZWTNYJTkGjcJUOBX5P0MHZrArJOkcrQsbyGWwlzJpZs961Y5YvKUw5MsAf8xLlvh7+1B8SO/VTvjMmVXFkD3w==}
-    engines: {node: '>=14.15.4'}
+  /automation-events@6.0.9:
+    resolution: {integrity: sha512-JEJzZRfRb26FMWR8zE2D/H/n5n+NNFZh1BtmDcpZVJOhLYKLGFCImBuxChRBhpZaOyIxqobPtM839amAeu2H9g==}
+    engines: {node: '>=16.1.0'}
     dependencies:
-      '@babel/runtime': 7.21.0
-      tslib: 2.5.0
+      '@babel/runtime': 7.22.15
+      tslib: 2.6.2
     dev: false
 
   /autoprefixer@10.4.14(postcss@8.4.23):
@@ -4785,12 +4785,12 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fast-unique-numbers@7.0.2:
-    resolution: {integrity: sha512-xnqpsnu889bHbq5cbDMwCJ2BPf6kjFPMu+RHfqKvisRxeEbTOVxY5aW/ZNsZ/r8OlwatxmjdFEVQog2xAhLkvg==}
-    engines: {node: '>=14.15.4'}
+  /fast-unique-numbers@8.0.8:
+    resolution: {integrity: sha512-TrtnK7tf1MfJ1gmWMM0rk6VGy2XVW8lV/7HjOUH+kd1gk27qHchDLhV83yq4NmASGA+ZnRozR99p2Sc2bE5s6Q==}
+    engines: {node: '>=16.1.0'}
     dependencies:
-      '@babel/runtime': 7.21.0
-      tslib: 2.5.0
+      '@babel/runtime': 7.22.15
+      tslib: 2.6.2
     dev: false
 
   /fastq@1.15.0:
@@ -7686,8 +7686,8 @@ packages:
       redis-errors: 1.2.0
     dev: true
 
-  /regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
     dev: false
 
   /regexp-tree@0.1.25:
@@ -8062,12 +8062,12 @@ packages:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
     dev: true
 
-  /standardized-audio-context@25.3.43:
-    resolution: {integrity: sha512-Wh/6rZCScDh3ZAsRy0kgeGF+g3mGO4E6UiWj8k79uCHKJjqiBJOtbwEFS1MBFfVXMHN3L3U3kn1aVrkCHtlkvw==}
+  /standardized-audio-context@25.3.56:
+    resolution: {integrity: sha512-f9pubvL/vilyGTQNa73dLX7bIa8V3XzBmKbfrgFF8Ac0EVdO2vIVQy9MSNDe/0pCot6ZxCxCzvVlHnEVHl8nRQ==}
     dependencies:
-      '@babel/runtime': 7.21.0
-      automation-events: 5.0.3
-      tslib: 2.5.0
+      '@babel/runtime': 7.22.15
+      automation-events: 6.0.9
+      tslib: 2.6.2
     dev: false
 
   /statuses@1.5.0:
@@ -8503,6 +8503,11 @@ packages:
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: true
+
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: false
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -9283,30 +9288,30 @@ packages:
     resolution: {integrity: sha512-CPi7qC0OcTE6HoQYIzwyWiJSl+Q+pcUa7jZOzlFcGt8kyOEdmPM2uo8IyGRQbJN/jzMdOgJKOwHxQ9akZhdOuw==}
     dev: false
 
-  /web-audio-beat-detector-broker@4.0.81:
-    resolution: {integrity: sha512-u67QM8/n2nmM/FIfSAMEPP2frP0nUI0djrI8pMbBBb9KavqR2I8yEzUVe1QfrZkiZG7vzRb0oJbM8topyS0ABQ==}
+  /web-audio-beat-detector-broker@4.0.90:
+    resolution: {integrity: sha512-OAi+4Ai7+w/a8Mpt4KpokKVsz9/FusmAz/d1D4JpP6uu8ty2Ks3FELN9I8g7K5+mj/7pWruV97aernsPLh2l0w==}
     dependencies:
-      '@babel/runtime': 7.21.0
-      fast-unique-numbers: 7.0.2
-      standardized-audio-context: 25.3.43
-      tslib: 2.5.0
-      web-audio-beat-detector-worker: 5.2.33
+      '@babel/runtime': 7.22.15
+      fast-unique-numbers: 8.0.8
+      standardized-audio-context: 25.3.56
+      tslib: 2.6.2
+      web-audio-beat-detector-worker: 5.2.41
     dev: false
 
-  /web-audio-beat-detector-worker@5.2.33:
-    resolution: {integrity: sha512-4+Tz+j1Mu6jrusYy1lNSzKrt+BcD/M41UunpvgwDTcvjfqsZwl424cSBb27TOIM4+mPoxETE1Q63seW8Toy3Kg==}
+  /web-audio-beat-detector-worker@5.2.41:
+    resolution: {integrity: sha512-k15iFBkrpXYFXq90X7KaKQtBtC46JCDUKWwOOVAvubf1eDdVBZJ+Dte0L4FAO0mvF8qk4lre0M8mk8kSaeJfAg==}
     dependencies:
-      '@babel/runtime': 7.21.0
-      tslib: 2.5.0
+      '@babel/runtime': 7.22.15
+      tslib: 2.6.2
     dev: false
 
-  /web-audio-beat-detector@8.1.44:
-    resolution: {integrity: sha512-4vkYyKOkC+bXmUp998Zy9E5Bu58N7h8EIOu69mTFR+Wom3pXEAtBl4IU6F5F7h8fxjDgd65oA7uquXKH5yZ4lQ==}
+  /web-audio-beat-detector@8.1.53:
+    resolution: {integrity: sha512-m+2W4db62m9MfoXI1CU2qVAMyUOzSmnHeotJsxuX0G7vsOkNEmho+zSLrP8nem4RZGbZPG5s3YuKfKvccsjwxw==}
     dependencies:
-      '@babel/runtime': 7.21.0
-      tslib: 2.5.0
-      web-audio-beat-detector-broker: 4.0.81
-      web-audio-beat-detector-worker: 5.2.33
+      '@babel/runtime': 7.22.15
+      tslib: 2.6.2
+      web-audio-beat-detector-broker: 4.0.90
+      web-audio-beat-detector-worker: 5.2.41
     dev: false
 
   /web-streams-polyfill@3.2.1:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^1.6.5
     version: 1.6.5
   wavesurfer.js:
-    specifier: ^7.1.5
-    version: 7.1.5
+    specifier: ^7.3.2
+    version: 7.3.2
   web-audio-beat-detector:
     specifier: ^8.1.44
     version: 8.1.44
@@ -66,7 +66,7 @@ devDependencies:
     version: 3.7.0(eslint@8.38.0)(typescript@5.0.4)(vue-tsc@1.2.0)
   nuxt-vitest:
     specifier: ^0.8.5
-    version: 0.8.5(@vitejs/plugin-vue-jsx@3.0.2)(@vitejs/plugin-vue@4.2.3)(vite@4.4.9)(vitest@0.31.4)(vue-router@4.2.4)(vue@3.3.4)
+    version: 0.8.5(@vitejs/plugin-vue-jsx@3.0.2)(@vitejs/plugin-vue@4.2.3)(vite@4.4.9)(vitest@0.31.4)(vue-router@4.2.5)(vue@3.3.4)
   postcss:
     specifier: ^8.4.23
     version: 8.4.23
@@ -1837,6 +1837,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: true
     bundledDependencies:
       - napi-wasm
@@ -2096,7 +2097,7 @@ packages:
     resolution: {integrity: sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==}
     dependencies:
       '@types/estree': 1.0.1
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.13
     dev: true
 
   /@types/estree@1.0.1:
@@ -2117,6 +2118,10 @@ packages:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
     dev: true
 
+  /@types/json-schema@7.0.13:
+    resolution: {integrity: sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==}
+    dev: true
+
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
@@ -2127,6 +2132,10 @@ packages:
 
   /@types/node@20.5.7:
     resolution: {integrity: sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==}
+    dev: true
+
+  /@types/node@20.6.3:
+    resolution: {integrity: sha512-HksnYH4Ljr4VQgEy2lTStbCKv/P590tmPe5HqOnv9Gprffgv5WXAY+Y5Gqniu0GGqeTCUdBnzC3QSrzPkBkAMA==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -3178,6 +3187,17 @@ packages:
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: true
 
+  /browserslist@4.21.11:
+    resolution: {integrity: sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001538
+      electron-to-chromium: 1.4.527
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.13(browserslist@4.21.11)
+    dev: true
+
   /browserslist@4.21.5:
     resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -3308,6 +3328,10 @@ packages:
 
   /caniuse-lite@1.0.30001524:
     resolution: {integrity: sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==}
+    dev: true
+
+  /caniuse-lite@1.0.30001538:
+    resolution: {integrity: sha512-HWJnhnID+0YMtGlzcp3T9drmBJUVDchPJ08tpUGFLs9CYlwWPH2uLgpHn8fND5pCgXVtnGS3H4QR9XLMHVNkHw==}
     dev: true
 
   /chai@4.3.7:
@@ -3997,6 +4021,10 @@ packages:
     resolution: {integrity: sha512-cSMwIAd8yUh54VwitVRVvHK66QqHWE39C3DRj8SWiXitEpVSY3wNPD9y1pxQtLIi4w3UdzF9klLsmuPshz09DQ==}
     dev: true
 
+  /electron-to-chromium@1.4.527:
+    resolution: {integrity: sha512-EafxEiEDzk2aLrdbtVczylHflHdHkNrpGNHIgDyA63sUQLQVS2ayj2hPw3RsVB42qkwURH+T2OxV7kGPUuYszA==}
+    dev: true
+
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
@@ -4100,8 +4128,8 @@ packages:
       which-typed-array: 1.1.9
     dev: true
 
-  /es-module-lexer@1.3.0:
-    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
+  /es-module-lexer@1.3.1:
+    resolution: {integrity: sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==}
     dev: true
 
   /es-set-tostringtag@2.0.1:
@@ -5661,7 +5689,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.5.7
+      '@types/node': 20.6.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -6284,6 +6312,10 @@ packages:
     hasBin: true
     dev: true
 
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: true
+
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
@@ -6513,7 +6545,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /nuxt-vitest@0.8.5(@vitejs/plugin-vue-jsx@3.0.2)(@vitejs/plugin-vue@4.2.3)(vite@4.4.9)(vitest@0.31.4)(vue-router@4.2.4)(vue@3.3.4):
+  /nuxt-vitest@0.8.5(@vitejs/plugin-vue-jsx@3.0.2)(@vitejs/plugin-vue@4.2.3)(vite@4.4.9)(vitest@0.31.4)(vue-router@4.2.5)(vue@3.3.4):
     resolution: {integrity: sha512-+KrPvQEIxZydjGyb/CNMPTcHuNssUehQK8Ng7lvFigD6GcAW6u/5wB2He8QiZ45NEfj1w4pTPbYkvOjdjhU8kw==}
     peerDependencies:
       '@vitejs/plugin-vue': '*'
@@ -6531,7 +6563,7 @@ packages:
       std-env: 3.3.3
       vite: 4.4.9
       vitest: 0.31.4
-      vitest-environment-nuxt: 0.8.5(vitest@0.31.4)(vue-router@4.2.4)(vue@3.3.4)
+      vitest-environment-nuxt: 0.8.5(vitest@0.31.4)(vue-router@4.2.5)(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - '@vue/server-renderer'
@@ -7818,7 +7850,7 @@ packages:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.13
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
     dev: true
@@ -8354,12 +8386,23 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      terser: 5.19.2
+      terser: 5.20.0
       webpack: 5.88.2
     dev: true
 
   /terser@5.19.2:
     resolution: {integrity: sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    dev: true
+
+  /terser@5.20.0:
+    resolution: {integrity: sha512-e56ETryaQDyebBwJIWYB2TT6f2EZ0fL0sW/JRXNMN26zZdKi2u/E/5my5lG6jNxym6qsrVXfFRmOdV42zlAgLQ==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -8813,6 +8856,17 @@ packages:
       picocolors: 1.0.0
     dev: true
 
+  /update-browserslist-db@1.0.13(browserslist@4.21.11):
+    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.11
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /uqr@0.1.2:
     resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
     dev: true
@@ -9009,7 +9063,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest-environment-nuxt@0.8.5(vitest@0.31.4)(vue-router@4.2.4)(vue@3.3.4):
+  /vitest-environment-nuxt@0.8.5(vitest@0.31.4)(vue-router@4.2.5)(vue@3.3.4):
     resolution: {integrity: sha512-uOtgoqUmO4MBzWe51vPLAieMjH5Ua2QGCziwStFYZQJBAQwX8zn/F/cNvc6590CLxlD4SHWY9WKIz8ehOI+A1w==}
     peerDependencies:
       vitest: ^0.24.5 || ^0.26.0 || ^0.27.0 || ^0.28.0 || ^0.29.0 || ^0.30.0
@@ -9027,7 +9081,7 @@ packages:
       unenv: 1.4.1
       vitest: 0.31.4
       vue: 3.3.4
-      vue-router: 4.2.4(vue@3.3.4)
+      vue-router: 4.2.5(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - '@vue/server-renderer'
@@ -9181,6 +9235,15 @@ packages:
       vue: 3.3.4
     dev: true
 
+  /vue-router@4.2.5(vue@3.3.4):
+    resolution: {integrity: sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
+      '@vue/devtools-api': 6.5.0
+      vue: 3.3.4
+    dev: true
+
   /vue-template-compiler@2.7.14:
     resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}
     dependencies:
@@ -9216,8 +9279,8 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
-  /wavesurfer.js@7.1.5:
-    resolution: {integrity: sha512-2zb82LxQzeFn5/O5JhEs1uytdlkksUDALWt7TPN8ppP4jrajuigwcM2g4wx6b+SO4Frweg/r99L1hznr0lsBEg==}
+  /wavesurfer.js@7.3.2:
+    resolution: {integrity: sha512-CPi7qC0OcTE6HoQYIzwyWiJSl+Q+pcUa7jZOzlFcGt8kyOEdmPM2uo8IyGRQbJN/jzMdOgJKOwHxQ9akZhdOuw==}
     dev: false
 
   /web-audio-beat-detector-broker@4.0.81:
@@ -9286,10 +9349,10 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.10.0
       acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.21.10
+      browserslist: 4.21.11
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
+      es-module-lexer: 1.3.1
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1


### PR DESCRIPTION
After upgrading to wavesurfer v7 the bpm calculation was broken.
The fix was simply reactivating the functionality at this point..